### PR TITLE
Disable opening web browser on npm start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules
 
 # Bower
 bower_components/
+
+# IDE/Editor data
+.idea

--- a/server.js
+++ b/server.js
@@ -6,12 +6,31 @@ const WebpackDevServer = require('webpack-dev-server');
 const config = require('./webpack.config');
 const open = require('open');
 
-new WebpackDevServer(webpack(config), config.devServer)
+/**
+ * Flag indicating whether webpack compiled for the first time.
+ * @type {boolean}
+ */
+let isInitialCompilation = true;
+
+const compiler = webpack(config);
+
+new WebpackDevServer(compiler, config.devServer)
 .listen(config.port, 'localhost', (err) => {
   if (err) {
     console.log(err);
   }
   console.log('Listening at localhost:' + config.port);
-  console.log('Opening your system browser...');
-  open('http://localhost:' + config.port + '/webpack-dev-server/');
+});
+
+compiler.plugin('done', () => {
+  if (isInitialCompilation) {
+    // Ensures that we log after webpack printed its stats (is there a better way?)
+    setTimeout(() => {
+      console.log('\n✓ The bundle is now ready for serving!\n');
+      console.log('  Open in iframe Mode:\t\x1b[33m%s\x1b[0m',  'http://localhost:' + config.port + '/webpack-dev-server/');
+      console.log('  Open in inline Mode:\t\x1b[33m%s\x1b[0m', 'http://localhost:' + config.port + '/\n');
+      console.log('  \x1b[33mHRM is active\x1b[0m. The bundle will automatically rebuild and live-update on changes.')
+    }, 350);
+  }
+  isInitialCompilation = false;
 });


### PR DESCRIPTION
This PR removed calling `open()` in `server.js` and added output with the dev server urls after the initial Webpack compilation.

Closes #47 